### PR TITLE
Fix yt_dlp postprocessor key

### DIFF
--- a/cogs/music_cog.py
+++ b/cogs/music_cog.py
@@ -88,7 +88,7 @@ class MusicCog(commands.Cog):
             'quiet': False,  # Disable quiet mode
             'logtostderr': True,  # Enable logging
             'postprocessors': [{
-                'key': 'FFmpegAudioConvertor',
+                'key': 'FFmpegExtractAudio',
                 'preferredcodec': 'mp3',
                 'preferredquality': '192',
             }]

--- a/player/core.py
+++ b/player/core.py
@@ -27,7 +27,7 @@ class MusicPlayer:
                 'outtmpl': 'downloads/%(id)s.%(ext)s',
                 'quiet': True,
                 'postprocessors': [{
-                    'key': 'FFmpegAudioConvertor',
+                    'key': 'FFmpegExtractAudio',
                     'preferredcodec': 'mp3',
                     'preferredquality': '192',
                 }],


### PR DESCRIPTION
## Summary
- fix incorrect `FFmpegAudioConvertor` key usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653d3262cc8321b3403a30496582e5