### PR TITLE
Handle TTS messages without command errors

### DIFF
--- a/cogs/tts_cog.py
+++ b/cogs/tts_cog.py
@@ -7,34 +7,19 @@ class TTSCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.Cog.listener()
-    async def on_message(self, message):
-        if message.author.bot:
-            return
+    async def play_tts(self, message, voice_name, text):
+        if message.author.voice:
+            vc = message.guild.voice_client
+            if not vc:
+                vc = await message.author.voice.channel.connect()
 
-        if not message.content.startswith('-'):
-            return
+            if vc.is_playing():
+                vc.stop()
 
-        parts = message.content[1:].split(maxsplit=1)
-        if not parts:
-            return
-
-        voice_name = parts[0].lower()
-        text = parts[1] if len(parts) > 1 else None
-
-        if voice_name in ELEVEN_VOICES and text:
-            if message.author.voice:
-                vc = message.guild.voice_client
-                if not vc:
-                    vc = await message.author.voice.channel.connect()
-
-                if vc.is_playing():
-                    vc.stop()
-
-                audio = await tts_to_pcm(text, ELEVEN_VOICES[voice_name])
-                vc.play(audio)
-            else:
-                await message.channel.send("🔇 You're not in a voice channel!")
+            audio = await tts_to_pcm(text, ELEVEN_VOICES[voice_name])
+            vc.play(audio)
+        else:
+            await message.channel.send("🔇 You're not in a voice channel!")
 
     @commands.command(name="listvoices", aliases=["lv"])
     async def list_voices(self, ctx):
@@ -43,3 +28,4 @@ class TTSCog(commands.Cog):
 
 async def setup(bot):
     await bot.add_cog(TTSCog(bot))
+


### PR DESCRIPTION
## Summary
- refactor `TTSCog` to expose a `play_tts` helper
- add custom `on_message` event in `bot.py` to handle voice commands
- process other commands normally

## Testing
- `python -m py_compile bot.py cogs/*.py utils/*.py player/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653f8d53d88321af29a665ab01440f