### PR TITLE
Fix voice reconnection for music cog

### DIFF
--- a/cogs/music_cog.py
+++ b/cogs/music_cog.py
@@ -25,7 +25,15 @@ class MusicCog(commands.Cog):
             return
         
         channel = ctx.author.voice.channel
-        if self.voice_client is None:
+
+        # Reconnect if our stored voice client is missing or stale
+        if self.voice_client is None or not self.voice_client.is_connected():
+            if self.voice_client is not None:
+                try:
+                    await self.voice_client.disconnect()
+                except Exception as e:
+                    self.logger.warning("Error disconnecting stale voice client: %s", e)
+
             self.voice_client = await channel.connect()
 
         # Get audio from YouTube or local file


### PR DESCRIPTION
## Summary
- reconnect voice client if stale or disconnected before playing

## Testing
- `python -m py_compile cogs/music_cog.py`

------
https://chatgpt.com/codex/tasks/task_e_68654dece31883219fa11ceee9830698