### PR TITLE
Add volume control commands

### DIFF
--- a/cogs/music_cog.py
+++ b/cogs/music_cog.py
@@ -3,7 +3,12 @@ from discord.ext import commands
 import yt_dlp
 import os
 import logging
-from config import LOCAL_MP3_FOLDER, FFMPEG_LOCAL_OPTIONS, LOCAL_FILE_VOLUME
+from config import (
+    LOCAL_MP3_FOLDER,
+    FFMPEG_LOCAL_OPTIONS,
+    LOCAL_MP3_VOLUME,
+    YOUTUBE_VOLUME,
+)
 from utils.audio import find_matching_audio
 
 ALIASES = {
@@ -60,7 +65,7 @@ class MusicCog(commands.Cog):
             abs_path = os.path.abspath(query)
             return discord.PCMVolumeTransformer(
                 discord.FFmpegPCMAudio(abs_path, **FFMPEG_LOCAL_OPTIONS),
-                volume=LOCAL_FILE_VOLUME,
+                volume=LOCAL_MP3_VOLUME,
             )
 
         # Try relative to configured folder
@@ -69,7 +74,7 @@ class MusicCog(commands.Cog):
             abs_path = os.path.abspath(candidate)
             return discord.PCMVolumeTransformer(
                 discord.FFmpegPCMAudio(abs_path, **FFMPEG_LOCAL_OPTIONS),
-                volume=LOCAL_FILE_VOLUME,
+                volume=LOCAL_MP3_VOLUME,
             )
 
         # Search the folder tree for a matching file
@@ -77,7 +82,7 @@ class MusicCog(commands.Cog):
         if matched:
             return discord.PCMVolumeTransformer(
                 discord.FFmpegPCMAudio(matched, **FFMPEG_LOCAL_OPTIONS),
-                volume=LOCAL_FILE_VOLUME,
+                volume=LOCAL_MP3_VOLUME,
             )
 
         self.logger.warning("No local audio found for query: %s", query)
@@ -110,7 +115,10 @@ class MusicCog(commands.Cog):
                 mp3_filename = base + '.mp3'
 
                 if os.path.exists(mp3_filename):
-                    return discord.FFmpegPCMAudio(mp3_filename)
+                    return discord.PCMVolumeTransformer(
+                        discord.FFmpegPCMAudio(mp3_filename),
+                        volume=YOUTUBE_VOLUME,
+                    )
                 else:
                     self.logger.error("Failed to download or convert the audio file from YouTube.")
                     return None

--- a/cogs/utility_cog.py
+++ b/cogs/utility_cog.py
@@ -1,13 +1,23 @@
 import os
 from discord.ext import commands
-from config import LOCAL_MP3_FOLDER
+import config
+from config import (
+    LOCAL_MP3_FOLDER,
+    MAX_VOLUME,
+    YOUTUBE_VOLUME,
+    LOCAL_MP3_VOLUME,
+    TTS_VOLUME,
+)
 from player.downloader import DownloadManager
 
 ALIASES = {
     'join': ['j'],
     'volume': ['v'],
     'listfiles': ['lf'],
-    'download': ['dl']
+    'download': ['dl'],
+    'ytvolume': ['ytv'],
+    'localmp3volume': ['lmp3v'],
+    'ttsvolume': ['ttsv'],
 }
 
 downloader = DownloadManager()
@@ -32,6 +42,23 @@ class UtilityCog(commands.Cog):
             await ctx.send(f"🔊 Volume set to {vol}")
         else:
             await ctx.send("⚠️ No audio source is playing.")
+
+    @commands.command(aliases=ALIASES['ytvolume'])
+    async def youtubevolume(self, ctx, vol: float):
+        config.YOUTUBE_VOLUME = min(vol, MAX_VOLUME)
+        config.DEFAULT_VOLUME = config.YOUTUBE_VOLUME
+        await ctx.send(f"🎵 YouTube volume set to {config.YOUTUBE_VOLUME}")
+
+    @commands.command(aliases=ALIASES['localmp3volume'])
+    async def localmp3volume(self, ctx, vol: float):
+        config.LOCAL_MP3_VOLUME = min(vol, MAX_VOLUME)
+        config.LOCAL_FILE_VOLUME = config.LOCAL_MP3_VOLUME
+        await ctx.send(f"📁 Local MP3 volume set to {config.LOCAL_MP3_VOLUME}")
+
+    @commands.command(aliases=ALIASES['ttsvolume'])
+    async def ttsvolume(self, ctx, vol: float):
+        config.TTS_VOLUME = min(vol, MAX_VOLUME)
+        await ctx.send(f"🗣️ TTS volume set to {config.TTS_VOLUME}")
 
     @commands.command(aliases=ALIASES['listfiles'])
     async def listfiles(self, ctx):

--- a/config.py
+++ b/config.py
@@ -20,8 +20,16 @@ FFMPEG_LOCAL_OPTIONS = {
 
 # Volume settings
 MAX_VOLUME = 1.0
-DEFAULT_VOLUME = 0.5
-LOCAL_FILE_VOLUME = 0.5
+
+# Default volumes for different audio sources. These values can be
+# adjusted at runtime via bot commands.
+YOUTUBE_VOLUME = 0.5
+LOCAL_MP3_VOLUME = 0.5
+TTS_VOLUME = 0.5
+
+# Backwards compatibility for modules that still import these names
+DEFAULT_VOLUME = YOUTUBE_VOLUME
+LOCAL_FILE_VOLUME = LOCAL_MP3_VOLUME
 
 # Voice map for ElevenLabs (command name -> voice ID)
 ELEVEN_VOICES = {

--- a/player/sources/local.py
+++ b/player/sources/local.py
@@ -2,7 +2,7 @@ import discord
 import os
 import logging
 import asyncio
-from config import FFMPEG_LOCAL_OPTIONS, LOCAL_FILE_VOLUME
+from config import FFMPEG_LOCAL_OPTIONS, LOCAL_MP3_VOLUME
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ class LocalSource:
 
         try:
             audio = discord.FFmpegPCMAudio(self.path, **FFMPEG_LOCAL_OPTIONS)
-            player = discord.PCMVolumeTransformer(audio, volume=LOCAL_FILE_VOLUME)
+            player = discord.PCMVolumeTransformer(audio, volume=LOCAL_MP3_VOLUME)
             logger.info(f"[LocalSource] Returning PCM transformer for: {self.path}")
             return player
         except Exception as e:

--- a/utils/tts.py
+++ b/utils/tts.py
@@ -1,7 +1,7 @@
 import aiohttp
 import tempfile
 import discord
-from config import ELEVEN_API_KEY, FFMPEG_LOCAL_OPTIONS, LOCAL_FILE_VOLUME
+from config import ELEVEN_API_KEY, FFMPEG_LOCAL_OPTIONS, TTS_VOLUME
 
 async def tts_to_pcm(text: str, voice_id: str) -> discord.PCMVolumeTransformer:
     url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
@@ -29,5 +29,5 @@ async def tts_to_pcm(text: str, voice_id: str) -> discord.PCMVolumeTransformer:
 
     return discord.PCMVolumeTransformer(
         discord.FFmpegPCMAudio(temp.name, **FFMPEG_LOCAL_OPTIONS),
-        volume=LOCAL_FILE_VOLUME
+        volume=TTS_VOLUME
     )


### PR DESCRIPTION
## Summary
- add separate volume settings in config
- support new volume variables in TTS and local audio sources
- add commands `ytv`, `lmp3v`, `ttsv` for adjusting volumes via chat
- apply YouTube volume when playing downloaded audio

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`