### PR TITLE
Fix reconnect issue in music cog

### DIFF
--- a/cogs/music_cog.py
+++ b/cogs/music_cog.py
@@ -122,7 +122,12 @@ class MusicCog(commands.Cog):
             await self.start_playback(ctx, title, source)
 
     async def start_playback(self, ctx, title, source):
-        if not self.voice_client or not self.voice_client.is_connected():
+        # Re-use an existing voice client if available instead of attempting
+        # to connect again which can raise ``ClientException`` when a previous
+        # connection is still being established.
+        self.voice_client = ctx.voice_client or self.voice_client
+
+        if not self.voice_client:
             if ctx.author.voice:
                 self.voice_client = await ctx.author.voice.channel.connect()
             else:


### PR DESCRIPTION
## Summary
- reuse an existing voice client in `start_playback`
- avoid reconnecting while a connection is still active

## Testing
- `python -m py_compile cogs/music_cog.py`

------
https://chatgpt.com/codex/tasks/task_e_6888dccb5af483219da01b74d5fe3097